### PR TITLE
Fix - Deprecated UTC Python Function

### DIFF
--- a/globalConfig.json
+++ b/globalConfig.json
@@ -718,8 +718,8 @@
                             "validators": [
                                 {
                                     "type": "regex",
-                                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
-                                    "errorMsg": "Start time must be in the format YYYY-MM-DDTHH:MM:SSZ (example:2023-01-01T00:00:00Z)"
+                                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z$",
+                                    "errorMsg": "Start time must be in the format YYYY-MM-DDTHH:MM:SSZ (example:2023-01-01T00:00:00.000Z)"
                                 }
                             ]
                         },

--- a/package/README.md
+++ b/package/README.md
@@ -231,3 +231,4 @@ The input uses checkpointing to avoid ingesting duplicate data. After the initia
 * Yuan Ling
 * Marie Duran
 * Ashley Hoang
+* Isaac Fonseca

--- a/package/bin/input_module_webex_admin_audit_events.py
+++ b/package/bin/input_module_webex_admin_audit_events.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dateutil.relativedelta import *
 
 from webex_constants import (
@@ -45,12 +45,12 @@ def collect_events(helper, ew):
     )
     access_token_expired_time = helper.get_check_point(expiration_checkpoint_key)
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     # update the access token if it expired
     if (
         not access_token_expired_time
-        or datetime.strptime(access_token_expired_time, "%m/%d/%Y %H:%M:%S") < now
+        or datetime.strptime(access_token_expired_time, "%m/%d/%Y %H:%M:%S").replace(tzinfo=timezone.utc) < now
     ):
 
         helper.log_debug(
@@ -115,10 +115,10 @@ def collect_events(helper, ew):
             ).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]+'Z'
 
         # set up end time
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         helper.log_debug("[-] now: {}".format(now))
 
-        if opt_end_time and datetime.strptime(opt_end_time, "%Y-%m-%dT%H:%M:%S.%fZ") < now:
+        if opt_end_time and datetime.strptime(opt_end_time, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)  < now:
             end_time = opt_end_time
         else:
             end_time = now.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]+'Z'

--- a/package/bin/input_module_webex_meeting_qualities.py
+++ b/package/bin/input_module_webex_meeting_qualities.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dateutil.relativedelta import *
 
 from webex_constants import (
@@ -46,9 +46,9 @@ def collect_events(helper, ew):
         ).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     # set up end time
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
-    if opt_end_time and datetime.strptime(opt_end_time, "%Y-%m-%dT%H:%M:%SZ") < now:
+    if opt_end_time and datetime.strptime(opt_end_time, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc) < now:
         end_time = opt_end_time
     else:
         end_time = now.strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -71,12 +71,12 @@ def collect_events(helper, ew):
     )
     access_token_expired_time = helper.get_check_point(expiration_checkpoint_key)
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     # update the access token if it expired
     if (
         not access_token_expired_time
-        or datetime.strptime(access_token_expired_time, "%m/%d/%Y %H:%M:%S") < now
+        or datetime.strptime(access_token_expired_time, "%m/%d/%Y %H:%M:%S").replace(tzinfo=timezone.utc) < now
     ):
 
         helper.log_debug(

--- a/package/bin/input_module_webex_meetings.py
+++ b/package/bin/input_module_webex_meetings.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dateutil.relativedelta import *
 
 from webex_constants import (
@@ -69,9 +69,9 @@ def collect_events(helper, ew):
         ).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     # set up end time
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
-    if opt_end_time and datetime.strptime(opt_end_time, "%Y-%m-%dT%H:%M:%SZ") < now:
+    if opt_end_time and datetime.strptime(opt_end_time, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc) < now:
         end_time = opt_end_time
     else:
         end_time = now.strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -98,12 +98,12 @@ def collect_events(helper, ew):
     )
     access_token_expired_time = helper.get_check_point(expiration_checkpoint_key)
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     # update the access token if it expired
     if (
         not access_token_expired_time
-        or datetime.strptime(access_token_expired_time, "%m/%d/%Y %H:%M:%S") < now
+        or datetime.strptime(access_token_expired_time, "%m/%d/%Y %H:%M:%S").replace(tzinfo=timezone.utc) < now
     ):
 
         helper.log_debug(

--- a/package/bin/input_module_webex_meetings_summary_report.py
+++ b/package/bin/input_module_webex_meetings_summary_report.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dateutil.relativedelta import *
 
 from webex_constants import (
@@ -46,12 +46,12 @@ def collect_events(helper, ew):
     )
     access_token_expired_time = helper.get_check_point(expiration_checkpoint_key)
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     # update the access token if it expired
     if (
         not access_token_expired_time
-        or datetime.strptime(access_token_expired_time, "%m/%d/%Y %H:%M:%S") < now
+        or datetime.strptime(access_token_expired_time, "%m/%d/%Y %H:%M:%S").replace(tzinfo=timezone.utc) < now
     ):
 
         helper.log_debug(
@@ -91,9 +91,9 @@ def collect_events(helper, ew):
         ).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     # set up end time
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
-    if opt_end_time and datetime.strptime(opt_end_time, "%Y-%m-%dT%H:%M:%SZ") < now:
+    if opt_end_time and datetime.strptime(opt_end_time, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc) < now:
         end_time = opt_end_time
     else:
         end_time = now.strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/package/bin/input_module_webex_security_audit_events.py
+++ b/package/bin/input_module_webex_security_audit_events.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dateutil.relativedelta import *
 
 from webex_constants import (
@@ -45,12 +45,12 @@ def collect_events(helper, ew):
     )
     access_token_expired_time = helper.get_check_point(expiration_checkpoint_key)
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     # update the access token if it expired
     if (
         not access_token_expired_time
-        or datetime.strptime(access_token_expired_time, "%m/%d/%Y %H:%M:%S") < now
+        or datetime.strptime(access_token_expired_time, "%m/%d/%Y %H:%M:%S").replace(tzinfo=timezone.utc) < now
     ):
 
         helper.log_debug(
@@ -115,10 +115,10 @@ def collect_events(helper, ew):
             ).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]+'Z'
 
         # set up end time
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         helper.log_debug("[-] now: {}".format(now))
 
-        if opt_end_time and datetime.strptime(opt_end_time, "%Y-%m-%dT%H:%M:%S.%fZ") < now:
+        if opt_end_time and datetime.strptime(opt_end_time, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc) < now:
             end_time = opt_end_time
         else:
             end_time = now.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]+'Z'

--- a/package/bin/oauth_helper.py
+++ b/package/bin/oauth_helper.py
@@ -1,6 +1,6 @@
 import import_declare_test
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from solnlib import conf_manager
 
 from webex_constants import _APP_NAME, _REALM, _TOKEN_EXPIRES_CHECKPOINT_KEY, _REFRESH_TOKEN_ENDPOINT
@@ -141,7 +141,7 @@ class OAuth:
             expiration_checkpoint_key = _TOKEN_EXPIRES_CHECKPOINT_KEY.format(account_name=account_name)
 
             # Calculate expired time for new access token
-            now = datetime.utcnow()
+            now = datetime.now(timezone.utc)
             delta = int(new_expires_in)
             expired_time = (now + timedelta(seconds=delta)).strftime(
                 "%m/%d/%Y %H:%M:%S"

--- a/package/bin/webex_detailed_call_history.py
+++ b/package/bin/webex_detailed_call_history.py
@@ -78,14 +78,14 @@ class ModInputWEBEX_DETAILED_CALL_HISTORY(base_mi.BaseModInput):
         locations = definition.parameters.get('locations', None)
         
         if start_time_start is not None:
-            start_time = datetime.strptime(start_time_start, "%Y-%m-%dT%H:%M:%SZ")
+            start_time = datetime.strptime(start_time_start, "%Y-%m-%dT%H:%M:%S.%fZ")
 
             if start_time <= datetime.now() - timedelta(days=2):
                 raise ValueError(
                     "Start time cannot be earlier than 48 hours ago. Please enter a date after {}.".format(datetime.strftime(datetime.now() - timedelta(days=2),"%Y-%m-%d")))
             
         if end_time_start is not None:
-            end_time = datetime.strptime(end_time_start, "%Y-%m-%dT%H:%M:%SZ")
+            end_time = datetime.strptime(end_time_start, "%Y-%m-%dT%H:%M:%S.%fZ")
             
             if end_time > datetime.now() + timedelta(days=2):
                  raise ValueError(

--- a/package/default/app.conf
+++ b/package/default/app.conf
@@ -6,7 +6,7 @@ build = 1
 [launcher]
 author = FDSE
 version = 1.1.0
-description = 
+description = This TA enables ingestion of data from multiple Cisco Webex APIs for comprehensive monitoring and analysis.
 
 [ui]
 is_visible = true


### PR DESCRIPTION
- Replaced the deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)`
- Changed the date format in the validation for the CDR input
- Updated app.conf to include a description for the [launcher] stanza