### PR TITLE
ci:added auto-assign pipeline

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -10,7 +10,22 @@ jobs:
   auto-assign:
     runs-on: ubuntu-latest
     steps:
+      - name: Check if issue opener is org member
+        id: is_org_member
+        uses: JamesSingleton/is-organization-member@1.1.0
+        with:
+          organization: splunk
+          username: ${{ github.event.issue.user.login }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add label "external"
+        if: steps.is_org_member.outputs.result == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh issue edit ${{ github.event.issue.number }} --add-label external
+
       - uses: pozil/auto-assign-issue@v2
+        if: steps.is_org_member.outputs.result == 'false'
         with:
           assignees: lingy1028,ahoang-splunk,ifonsecam
           numOfAssignee: 1


### PR DESCRIPTION
## Added
- CI/CD pipeline to automatically assign issues opened by externals. Externals mean users which are not part of gh splunk organization.