### PR TITLE
ci(auto-assign):added fix for the auto-assign issue automation

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -21,8 +21,11 @@ jobs:
       - name: Add label "external"
         if: steps.is_org_member.outputs.result == 'false'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh issue edit ${{ github.event.issue.number }} --add-label external
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: external
+        run: gh issue edit "$NUMBER" --add-label "$LABELS"
 
       - uses: pozil/auto-assign-issue@v2
         if: steps.is_org_member.outputs.result == 'false'


### PR DESCRIPTION
Edited `auto-assign.yml` pipeline as per [docs](https://docs.github.com/en/actions/tutorials/manage-your-work/add-labels-to-issues). In response to [this automation failure](https://github.com/splunk/ta_cisco_webex_add_on_for_splunk/actions/runs/20239632016).

@lingy1028  I also added the `external` label among [labels](https://github.com/splunk/ta_cisco_webex_add_on_for_splunk/issues/labels) to comply with docs requesting that _"The label(s) must exist for your repository."_