### PR TITLE
fix: one item's API error stalls the per-loop checkpoint (webex_meetings + webex_meeting_qualities)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 
 - `webex_meetings` input re-ingested every meeting on every interval whenever a single host's meetings request failed (e.g. a Webex `502`). The checkpoint is saved only after the entire per-host loop completes, so one failing host aborted the run before `save_check_point()`, leaving the checkpoint unset and the dedup comparison permanently falling back to `start_time`. The per-host fetch and write now log and continue instead of raising, so the checkpoint advances and duplicate ingestion stops.
+- `webex_meeting_qualities` input had the same defect in its per-meeting loop: the checkpoint is saved only after the entire loop completes, so a single meeting's qualities request failing aborted the run before `save_check_point()`. This is triggered permanently rather than transiently — quality data expires 14 days after a meeting, after which `GET /v1/meeting/qualities` returns `425` ("Quality data is not available for this meeting because it has expired after 14 days") for that meeting on every run. With the checkpoint pinned, every meeting in the window was re-ingested every interval. The per-meeting qualities fetch and write now log and continue instead of raising, so the checkpoint advances past expired/failing meetings and duplicate ingestion stops.
 
 ## [v1.4.2] - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- `webex_meetings` input re-ingested every meeting on every interval whenever a single host's meetings request failed (e.g. a Webex `502`). The checkpoint is saved only after the entire per-host loop completes, so one failing host aborted the run before `save_check_point()`, leaving the checkpoint unset and the dedup comparison permanently falling back to `start_time`. The per-host fetch and write now log and continue instead of raising, so the checkpoint advances and duplicate ingestion stops.
+
 ## [v1.4.2] - 2026-05-28
 
 ### Fixed

--- a/package/bin/input_module_webex_meeting_qualities.py
+++ b/package/bin/input_module_webex_meeting_qualities.py
@@ -85,19 +85,34 @@ def collect_events(helper, ew):
 
         if meeting_start_time > last_checkpoint_time and meeting.get("id", None):
             meetings_qualities_params = {"meetingId": meeting["id"], "max": 1000}
-            meetings_qualities_data_list = paging_get_request_to_webex(
-                helper,
-                base_endpoint,
-                _GET_MEETING_QUALITIES,
-                access_token,
-                refresh_token,
-                account_name,
-                client_id,
-                client_secret,
-                meetings_qualities_params,
-                _RESPONSE_TAG_MAP[_GET_MEETING_QUALITIES],
-                webex_account_region=account_region
-            )
+            # A single meeting's qualities fetch can fail transiently (e.g. Webex 502) or
+            # PERMANENTLY: quality data expires 14 days after the meeting, after which this
+            # endpoint returns 425 ("Quality data is not available for this meeting because
+            # it has expired after 14 days") on every call, forever. Do NOT let one meeting
+            # abort the whole run: that skips save_check_point() below, so the checkpoint
+            # never advances and EVERY meeting in the window is re-ingested on every interval
+            # (unbounded duplicates). Log and skip this meeting; the checkpoint still advances
+            # past it via the other meetings in the window. Trade-off: a persistently-failing
+            # meeting's qualities are not captured -- acceptable vs. stalling all meetings.
+            try:
+                meetings_qualities_data_list = paging_get_request_to_webex(
+                    helper,
+                    base_endpoint,
+                    _GET_MEETING_QUALITIES,
+                    access_token,
+                    refresh_token,
+                    account_name,
+                    client_id,
+                    client_secret,
+                    meetings_qualities_params,
+                    _RESPONSE_TAG_MAP[_GET_MEETING_QUALITIES],
+                    webex_account_region=account_region
+                )
+            except Exception as e:
+                helper.log_error(
+                    "[-] Skipping meeting {} for this run due to qualities API error: {}".format(meeting["id"], e)
+                )
+                continue
             helper.log_debug("[-] meetings qualities data list size: {} for meeting: {}".format(len(meetings_qualities_data_list), meeting["id"]))
 
             if len(meetings_qualities_data_list) > 0:
@@ -117,8 +132,11 @@ def collect_events(helper, ew):
                         )
                         ew.write_event(meeting_quality_event)
                 except Exception as e:
-                    helper.log_error("[-] Error happened while writing meetings qualities into Splunk: {}".format(e))
-                    raise e
+                    # Same rationale as the fetch above: a write/parse failure for one
+                    # meeting must not abort the run and block the checkpoint save. Log
+                    # and move on to the next meeting.
+                    helper.log_error("[-] Error happened while writing meetings qualities into Splunk for meeting {}: {}".format(meeting["id"], e))
+                    continue
                 latest_time = last_checkpoint_time if latest_time is None else latest_time
                 latest_time = max(latest_time, meeting_start_time)
 

--- a/package/bin/input_module_webex_meetings.py
+++ b/package/bin/input_module_webex_meetings.py
@@ -86,19 +86,32 @@ def collect_events(helper, ew):
         if user.get("emails", None):
             for email in user["emails"]:
                 meetings_params["hostEmail"] = email
-                # fetching the meetings data for each user
-                meetings = paging_get_request_to_webex(
-                    helper,
-                    base_endpoint,
-                    _MEETINGS_ENDPOINT,
-                    access_token,
-                    refresh_token,
-                    account_name,
-                    client_id,
-                    client_secret,
-                    meetings_params,
-                    _RESPONSE_TAG_MAP[_MEETINGS_ENDPOINT],
-                )
+                # fetching the meetings data for each user.
+                # A single host can fail transiently (e.g. Webex 502) or persistently
+                # (a host the API consistently chokes on). Do NOT let one host abort the
+                # whole run: that skips save_check_point() at the end, so the checkpoint
+                # never advances and EVERY meeting is re-ingested on every interval
+                # (unbounded duplicates). Log and skip this host; the checkpoint still
+                # advances for the rest. Trade-off: a persistently-failing host's meetings
+                # in this window are not captured -- acceptable vs. stalling all hosts.
+                try:
+                    meetings = paging_get_request_to_webex(
+                        helper,
+                        base_endpoint,
+                        _MEETINGS_ENDPOINT,
+                        access_token,
+                        refresh_token,
+                        account_name,
+                        client_id,
+                        client_secret,
+                        meetings_params,
+                        _RESPONSE_TAG_MAP[_MEETINGS_ENDPOINT],
+                    )
+                except Exception as e:
+                    helper.log_error(
+                        "[-] Skipping host {} for this run due to API error: {}".format(email, e)
+                    )
+                    continue
                 helper.log_debug("[-] meetings data size: {} for user: {}".format(len(meetings), email))
                 # helper.log_debug("[-] meetings data for user: {}\n{}".format(email, meetings))
 
@@ -134,10 +147,13 @@ def collect_events(helper, ew):
                             )
                             ew.write_event(meeting_event)
                 except Exception as e:
+                    # Same rationale as the fetch above: a write/parse failure for one
+                    # host must not abort the run and block the checkpoint save. Log and
+                    # move on to the next host.
                     helper.log_error(
-                        "[-] Error happened while writing data into Splunk: {}".format(e)
+                        "[-] Error happened while writing data into Splunk for host {}: {}".format(email, e)
                     )
-                    raise e
+                    continue
     # save the end_time of the last round as checkpoint for next ingestion
     helper.save_check_point(last_timestamp_checkpoint_key, end_time)
     helper.log_debug("[-] Saved checkpoint: Last run time saved: {}".format(helper.get_check_point(last_timestamp_checkpoint_key)))


### PR DESCRIPTION
Refs #30 (root-cause + proper fix discussed there).

## Problem (short version)

Two inputs — `webex_meetings` and `webex_meeting_qualities` — re-ingest **every item on
every interval** whenever a single per-item sub-request fails. Both optimistically save
their checkpoint only after the whole loop so any error hits the raise, never gets to
`save_check_point()`; the dedup gate then falls back to `start_time` every run and
re-writes everything.

- **`webex_meetings`** — one host's meetings fetch fails (observed: we had a persistent
  `502` on one `hostEmail`).
- **`webex_meeting_qualities`** — same problem, but much more pervasive as every install
  will hit this because quality data expires 14 days after a meeting. The first request
  afterwards will get a `425` ("Quality data is not available for this meeting because
  it has expired after 14 days") for that meeting forever. Any window older than 14 days
  thus contains a guaranteed "poison" meeting, so this input re-duplicates on every interval
  indefinitely.

## This PR: interim, stop-the-bleeding fix

Change so that on encountering unexpected responses, it logs and continues instead of
aborting, in both inputs. Thus any one bad item is skipped and the checkpoint still
advances for the rest. Scope is limited to control flow inside `collect_events` (per each
file's edit guidance) plus `CHANGELOG.md` `[Unreleased]` entries. For `meeting_qualities`
the trade-off is essentially free: a meeting whose quality data has expired is unrecoverable
at the source, so skipping it loses nothing. For `webex_meetings` the trade-off is real — a
persistently failing host's meetings are skipped for that window — so this is a stop-gap; the
more comprehensive fix is a per-host checkpoint keyed by `hostEmail` (see #30).

## Verification

This repo has no functional test harness, so both fixes were validated by live reproduction
on a production instance:

- **`meeting_qualities`** — confirmed end-to-end: with the expired-meeting `425` reproducing
  every 5-minute run, duplicate ingestion dropped from a steady ~36 rows/30 min to zero at
  deploy, and the KV Store checkpoint advanced to current for the first time.
- **`webex_meetings`** — the failing host in our environment recovered before deploy, so the
  skip path hasn't been exercised there since; it is the identical control-flow change,
  validated by the `meeting_qualities` case above.