### PR TITLE
Bundle httplib2 0.22.0 to fix proxy auth encode error and bump v…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v1.4.3] - 2026-07-02
+
+### Fixed
+
+- Fixed the "'bytes' object has no attribute 'encode'" error when using a proxy with credentials by bundling httplib2 0.22.0 with the add-on.
+
 ## [v1.4.2] - 2026-05-28
 
 ### Fixed

--- a/globalConfig.json
+++ b/globalConfig.json
@@ -2,7 +2,7 @@
     "meta": {
         "name": "ta_cisco_webex_add_on_for_splunk",
         "displayName": "Cisco Webex Add-on for Splunk",
-        "version": "1.4.2",
+        "version": "1.4.3",
         "restRoot": "ta_cisco_webex_add_on_for_splunk",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/package/app.manifest
+++ b/package/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null, 
       "name": "ta_cisco_webex_add_on_for_splunk", 
-      "version": "1.4.2"
+      "version": "1.4.3"
     }, 
     "author": [
       {

--- a/package/lib/requirements.txt
+++ b/package/lib/requirements.txt
@@ -1,3 +1,3 @@
-splunktaucclib==8.0.0
+splunktaucclib==8.2.0
 splunk-sdk==2.1.0
 httplib2==0.22.0

--- a/package/lib/requirements.txt
+++ b/package/lib/requirements.txt
@@ -1,2 +1,3 @@
 splunktaucclib==8.0.0
 splunk-sdk==2.1.0
+httplib2==0.22.0


### PR DESCRIPTION
Add `httplib2==0.22.0` to package requirements so the add-on ships its own `httplib2` instead of relying on the Splunk platform version, which fixes"'bytes' object has no attribute 'encode'" in socks set_proxy when using a proxy with credentials. 